### PR TITLE
Change Gradio theme to Monochrome

### DIFF
--- a/main.py
+++ b/main.py
@@ -90,7 +90,7 @@ def run(port):
         logging.info(f"Starting Gradio interface on port {port}...")
         chat_interface = gr.ChatInterface(
             fn=predict, 
-            theme=gr.themes.Soft(),
+            theme=gr.themes.Monochrome(),
             title=title,
             description=description
         )


### PR DESCRIPTION
Related to #1

Updates the Gradio interface theme from Soft to Monochrome in the `main.py` file.

- Changes the `theme` parameter in the `gr.ChatInterface` function call to `gr.themes.Monochrome()` to set the Gradio interface theme to Monochrome, aligning with the requested theme change.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sombaner/aro-azureopenai/issues/1?shareId=54629306-1386-45cb-95bc-a40f18c70d5b).